### PR TITLE
correct changing directory destination for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The file documentation.pdf should have been generated in /Users/myusername/userc
 Run the following commands for cloning this repo and installing the Python package for md2pdf.
 
         git clone git@github.com:Fiware/tools.Md2pdf.git
-        cd markdown_to_pdf
+        cd tools.Md2pdf/
         sudo python setup.py install
 
 ### Usage


### PR DESCRIPTION
correct instructions for changing directory to run the installation with `setup.py`.

There is a `setup.py` located in the root directory of this project unlike the previous directory `markdown_to_pdf`.

I have tested the installation and everything was successful with the latest change.