### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/markdown_to_pdf/check_requirements.py
+++ b/markdown_to_pdf/check_requirements.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import subprocess
 import sys
 import os
@@ -22,7 +23,7 @@ def is_pandoc_installed():
     try:
         subprocess.check_call(["pandoc","--version"],stdout=FNULL, stderr=subprocess.STDOUT)
     except Exception as e:
-        print "Aborted: pandoc is not correctly installed."
+        print("Aborted: pandoc is not correctly installed.")
         sys.exit(1)
         FNULL.close()
 
@@ -32,7 +33,7 @@ def is_pdftk_installed():
     try:
         subprocess.check_call(["pdftk","--version"],stdout=FNULL, stderr=subprocess.STDOUT)
     except Exception as e:
-        print "Aborted: pdftk is not correctly installed."
+        print("Aborted: pdftk is not correctly installed.")
         sys.exit(1)
         FNULL.close()
 
@@ -44,7 +45,7 @@ def is_xelatex_installed():
     try:
         subprocess.check_call(["xelatex","--version"],stdout=FNULL, stderr=subprocess.STDOUT)
     except Exception as e:
-        print "Aborted: xelatex is not correctly installed."
+        print("Aborted: xelatex is not correctly installed.")
         sys.exit(1)
         FNULL.close()
 
@@ -56,7 +57,7 @@ def is_false_installed():
     try:
         subprocess.check_call(["false_program","--version"],stdout=FNULL, stderr=subprocess.STDOUT)
     except Exception as e:
-        print "Aborted: false_program is not correctly installed"
+        print("Aborted: false_program is not correctly installed")
         sys.exit(1)
         FNULL.close()
 

--- a/markdown_to_pdf/hyphenate.py
+++ b/markdown_to_pdf/hyphenate.py
@@ -13,6 +13,7 @@
     Ned Batchelder, July 2007.
     This Python code is in the public domain.
 """
+from __future__ import print_function
 
 import re
 
@@ -517,7 +518,7 @@ if __name__ == '__main__':
     import sys
     if len(sys.argv) > 1:
         for word in sys.argv[1:]:
-            print '-'.join(hyphenate_word(word))
+            print('-'.join(hyphenate_word(word)))
     else:
         import doctest
         doctest.testmod(verbose=True)

--- a/markdown_to_pdf/markdown_to_pdf.py
+++ b/markdown_to_pdf/markdown_to_pdf.py
@@ -36,7 +36,7 @@ def get_markdown_filepaths(configuration_filepath):
 
     try:
         configuration_file_content['files_order']
-    except Exception, e:
+    except Exception:
         #try to load from RTD yml format
         configuration_file_content['files_order'] = convert_md_filepaths_from_RTD_format(configuration_filepath)
 
@@ -57,7 +57,7 @@ def convert_md_filepaths_from_RTD_format(configuration_filepath):
 
     try:
         prefix = "./"+configuration_file_content['docs_dir']
-    except Exception, e:
+    except Exception:
         prefix = ""
 
     for page in configuration_file_content['pages']:
@@ -343,7 +343,7 @@ def generate_default_cover_file(input_conf_file, output_file):
         
         configuration['cover_metadata'] = configuration_file_content['cover_metadata']
 
-    except Exception, e:
+    except Exception:
         #load default values
         cover_template_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'cover_template')
         default_cover_conf_file = os.path.join(cover_template_dir, 'default_cover_metadata.yml')
@@ -353,13 +353,13 @@ def generate_default_cover_file(input_conf_file, output_file):
         try:
             #try to obtain site_name
             default_configuration_file_content['cover_metadata']['title']=configuration_file_content['site_name']
-        except Exception as e:
+        except Exception:
             pass        
         
         try:
             #try to obtain site description
             default_configuration_file_content['cover_metadata']['description']=configuration_file_content['site_description']
-        except Exception as e:
+        except Exception:
             pass
 
         configuration['cover_metadata'] = default_configuration_file_content['cover_metadata']


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Old style exceptions to new style.